### PR TITLE
Client can now create a new itinerary and view a list of trip itineraries

### DIFF
--- a/src/components/itineraries/Itineraries.js
+++ b/src/components/itineraries/Itineraries.js
@@ -1,0 +1,31 @@
+// Generates the itineraries list
+
+import { useEffect, useState } from "react"
+import { getItinerariesByTrip } from "../managers/ItineraryManager"
+import { Link } from "react-router-dom"
+import { Itinerary } from "./Itinerary"
+
+export const Itineraries = ({ tripId }) => {
+
+const [itineraries, setItineraries] = useState([])
+
+useEffect(
+    () => {
+        getItinerariesByTrip(tripId)
+        .then( itinerariesArray => {
+            setItineraries(itinerariesArray)
+        })
+    },
+    []
+) 
+
+return <>
+        <h5 style={{textAlign: 'center'}}>Trip Itineraries</h5>
+        <div className="row">
+            {
+                itineraries.map( itinerary => <Itinerary key={`itinerary--${itinerary.id}`} itinerary={itinerary}/>)
+            }
+        </div>
+    </>
+
+}

--- a/src/components/itineraries/Itineraries.js
+++ b/src/components/itineraries/Itineraries.js
@@ -20,7 +20,6 @@ useEffect(
 ) 
 
 return <>
-        <h5 style={{textAlign: 'center'}}>Trip Itineraries</h5>
         <div className="row">
             {
                 itineraries.map( itinerary => <Itinerary key={`itinerary--${itinerary.id}`} itinerary={itinerary}/>)

--- a/src/components/itineraries/Itinerary.js
+++ b/src/components/itineraries/Itinerary.js
@@ -1,0 +1,31 @@
+//Generates the itinerary card to be displayed in the itinerary list
+
+import { Link } from "react-router-dom"
+
+export const Itinerary = ({ itinerary }) => {
+
+    return <>
+        <div className="col-sm-6">
+            <div className="card my-5 mx-5">
+                <div className="card-body">
+                    <h5 className="card-title mb-3">{itinerary.name}</h5>
+                    <p className="card-text">
+                        {itinerary.date}
+                    </p>
+                    <p className="card-text">
+                        {itinerary.start_time} through {itinerary.end_time}
+                    </p>
+                    <p className="card-text">
+                        {itinerary.city}, {itinerary.state_or_country}
+                    </p>
+                    <p className="card-text">
+                        Category: {
+                            itinerary?.categories?.map(category => category?.category).join(", ")
+                        }
+                    </p>  
+                    <Link to={`/itineraries/${itinerary.id}`} className="btn btn-outline-primary">View Itinerary Details</Link>
+                </div>
+            </div>
+        </div>
+    </>
+}

--- a/src/components/itineraries/ItineraryDetails.js
+++ b/src/components/itineraries/ItineraryDetails.js
@@ -1,0 +1,31 @@
+// Displays the details of the itinerary
+
+import { useState, useEffect } from "react"
+import { useParams } from "react-router-dom"
+import { Link } from "react-router-dom"
+import { getItinerary } from "../managers/ItineraryManager"
+
+export const ItineraryDetails = () => {
+    const { itineraryId } = useParams()
+    const [itinerary, setItinerary] = useState({
+        "name": "",
+        "itinerary_description": "",
+        "date": "",
+        "start_time": "",
+        "end_time": "",
+        "city": "",
+        "state_or_country": "",
+        "trip_id": 0,
+        "categories": []
+    })
+
+    useEffect(() => {
+        const id = parseInt(itineraryId)
+        getItinerary(id).then(data => setItinerary(data))
+    }, [itineraryId])
+
+    return <>
+        <h5>{itinerary.name}</h5>
+        <p>{itinerary.itinerary_description}</p>
+    </>
+}

--- a/src/components/itineraries/ItineraryDetails.js
+++ b/src/components/itineraries/ItineraryDetails.js
@@ -8,15 +8,15 @@ import { getItinerary } from "../managers/ItineraryManager"
 export const ItineraryDetails = () => {
     const { itineraryId } = useParams()
     const [itinerary, setItinerary] = useState({
-        "name": "",
-        "itinerary_description": "",
-        "date": "",
-        "start_time": "",
-        "end_time": "",
-        "city": "",
-        "state_or_country": "",
-        "trip_id": 0,
-        "categories": []
+        name: "",
+        itinerary_description: "",
+        date: "",
+        start_time: "",
+        end_time: "",
+        city: "",
+        state_or_country: "",
+        trip_id: 0,
+        categories: []
     })
 
     useEffect(() => {

--- a/src/components/itineraries/ItineraryForm.js
+++ b/src/components/itineraries/ItineraryForm.js
@@ -3,9 +3,9 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { Link } from "react-router-dom"
 import { getItinerary, createItinerary, updateItinerary, getCategories } from "../managers/ItineraryManager"
 
-export const ItineraryForm = ({ tripId }) => {
-    const { itineraryId } = useParams()
+export const ItineraryForm = () => {
     const navigate = useNavigate()
+    const { tripId } = useParams()
     const [categories, setCategories] = useState([])
     const [itineraryCategories, setItineraryCategories] = useState(new Set())
     const [currentItinerary, setCurrentItinerary] = useState({
@@ -16,7 +16,7 @@ export const ItineraryForm = ({ tripId }) => {
         end_time: "",
         city: "",
         state_or_country: "",
-        trip: 0,
+        trip: tripId,
         categories: []
     })
     
@@ -25,20 +25,6 @@ export const ItineraryForm = ({ tripId }) => {
         copy.has(categoryId) ? copy.delete(categoryId) : copy.add(categoryId)
         setItineraryCategories(copy)
     }
-
-    useEffect(() => {
-        if (itineraryId) {
-            getItinerary(itineraryId)
-                .then((itinerary) => {   
-                    setCurrentItinerary(itinerary)
-                    const categorySet = new Set()
-                    for (const category of itinerary.categories) {
-                        categorySet.add(category.id)
-                    }
-                    setItineraryCategories(categorySet)
-            })
-        }
-    }, [itineraryId])
 
     useEffect(() => {
         getCategories().then(data => setCategories(data))
@@ -53,16 +39,40 @@ export const ItineraryForm = ({ tripId }) => {
 
     return (
         <form className="itineraryForm">
-            <h2 className="itineraryForm__title">
-                {
-                    itineraryId ? "Update Itinerary Information" : "Add Itinerary Information"
-                }
-            </h2>
+            <h2 className="itineraryForm__title">Itinerary Information</h2>
             <fieldset>
                 <div className="form-group">
                     <label htmlFor="name">Name: </label>
                     <input type="text" name="name" required autoFocus className="form-control"
                         value={currentItinerary.name}
+                        onChange={changeItineraryState}
+                    />
+                </div>
+                <div className="form-group">
+                    <label htmlFor="itinerary_description">Itinerary Description: </label>
+                    <input type="text" name="itinerary_description" required autoFocus className="form-control"
+                        value={currentItinerary.itinerary_description}
+                        onChange={changeItineraryState}
+                    />
+                </div>
+                <div className="form-group">
+                    <label htmlFor="date">Date:</label>
+                    <input type="date" name="date" required autoFocus className="form-control"
+                        value={currentItinerary.date}
+                        onChange={changeItineraryState}
+                    />
+                </div>
+                <div className="form-group">
+                    <label htmlFor="start_time">Start Time:</label>
+                    <input type="time" name="start_time" required autoFocus className="form-control"
+                        value={currentItinerary.start_time}
+                        onChange={changeItineraryState}
+                    />
+                </div>
+                <div className="form-group">
+                    <label htmlFor="end_time">End Time:</label>
+                    <input type="time" name="end_time" required autoFocus className="form-control"
+                        value={currentItinerary.end_time}
                         onChange={changeItineraryState}
                     />
                 </div>
@@ -77,20 +87,6 @@ export const ItineraryForm = ({ tripId }) => {
                     <label htmlFor="state_or_country">State / Country </label>
                     <input type="text" name="state_or_country" required autoFocus className="form-control"
                         value={currentItinerary.state_or_country}
-                        onChange={changeItineraryState}
-                    />
-                </div>
-                <div className="form-group">
-                    <label htmlFor="departure_date">Departure Date:</label>
-                    <input type="date" name="departure_date" required autoFocus className="form-control"
-                        value={currentItinerary.departure_date}
-                        onChange={changeItineraryState}
-                    />
-                </div>
-                <div className="form-group">
-                    <label htmlFor="return_date">Return Date:</label>
-                    <input type="date" name="return_date" required autoFocus className="form-control"
-                        value={currentItinerary.return_date}
                         onChange={changeItineraryState}
                     />
                 </div>
@@ -118,7 +114,6 @@ export const ItineraryForm = ({ tripId }) => {
                         evt.preventDefault()
 
                         const itinerary = {
-                            id: currentItinerary.id,
                             name: currentItinerary.name,
                             itinerary_description: currentItinerary.itinerary_description,
                             date: currentItinerary.date,
@@ -130,15 +125,9 @@ export const ItineraryForm = ({ tripId }) => {
                             categories: Array.from(itineraryCategories)
                         }
 
-                        // If there is a itineraryId route parameter, invoke updateItinerary, otherwise createItinerary
-                        itineraryId ? updateItinerary(itineraryId, itinerary).then(() => navigate(`/trips/${tripId}`))
-                        : createItinerary(itinerary).then(() => navigate(`/trips/${tripId}`))
+                        createItinerary(itinerary).then(() => navigate(`/trips/${tripId}`))
                     }}
-                    className="btn btn-primary col-3">
-                        {
-                            itineraryId ? "Update" : "Create"
-                        }
-                </button>
+                    className="btn btn-primary col-3">Create</button>
                 <Link to={`/trips/${tripId}`} className="btn btn-primary col-3">Close</Link>
             </div>
         </form>

--- a/src/components/itineraries/ItineraryForm.js
+++ b/src/components/itineraries/ItineraryForm.js
@@ -1,0 +1,146 @@
+import { useState, useEffect } from "react"
+import { useNavigate, useParams } from 'react-router-dom'
+import { Link } from "react-router-dom"
+import { getItinerary, createItinerary, updateItinerary, getCategories } from "../managers/ItineraryManager"
+
+export const ItineraryForm = ({ tripId }) => {
+    const { itineraryId } = useParams()
+    const navigate = useNavigate()
+    const [categories, setCategories] = useState([])
+    const [itineraryCategories, setItineraryCategories] = useState(new Set())
+    const [currentItinerary, setCurrentItinerary] = useState({
+        name: "",
+        itinerary_description: "",
+        date: "",
+        start_time: "",
+        end_time: "",
+        city: "",
+        state_or_country: "",
+        trip: 0,
+        categories: []
+    })
+    
+    const categoryArr = (categoryId) => {
+        let copy = new Set(itineraryCategories)
+        copy.has(categoryId) ? copy.delete(categoryId) : copy.add(categoryId)
+        setItineraryCategories(copy)
+    }
+
+    useEffect(() => {
+        if (itineraryId) {
+            getItinerary(itineraryId)
+                .then((itinerary) => {   
+                    setCurrentItinerary(itinerary)
+                    const categorySet = new Set()
+                    for (const category of itinerary.categories) {
+                        categorySet.add(category.id)
+                    }
+                    setItineraryCategories(categorySet)
+            })
+        }
+    }, [itineraryId])
+
+    useEffect(() => {
+        getCategories().then(data => setCategories(data))
+    }, [])
+
+    const changeItineraryState = (event) => {
+        const copy = { ...currentItinerary }
+        copy[event.target.name] = event.target.value
+        setCurrentItinerary(copy)
+    }
+
+
+    return (
+        <form className="itineraryForm">
+            <h2 className="itineraryForm__title">
+                {
+                    itineraryId ? "Update Itinerary Information" : "Add Itinerary Information"
+                }
+            </h2>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="name">Name: </label>
+                    <input type="text" name="name" required autoFocus className="form-control"
+                        value={currentItinerary.name}
+                        onChange={changeItineraryState}
+                    />
+                </div>
+                <div className="form-group">
+                    <label htmlFor="city">City</label>
+                    <input type="text" name="city" required autoFocus className="form-control"
+                        value={currentItinerary.city}
+                        onChange={changeItineraryState}
+                    />
+                </div>
+                <div className="form-group">
+                    <label htmlFor="state_or_country">State / Country </label>
+                    <input type="text" name="state_or_country" required autoFocus className="form-control"
+                        value={currentItinerary.state_or_country}
+                        onChange={changeItineraryState}
+                    />
+                </div>
+                <div className="form-group">
+                    <label htmlFor="departure_date">Departure Date:</label>
+                    <input type="date" name="departure_date" required autoFocus className="form-control"
+                        value={currentItinerary.departure_date}
+                        onChange={changeItineraryState}
+                    />
+                </div>
+                <div className="form-group">
+                    <label htmlFor="return_date">Return Date:</label>
+                    <input type="date" name="return_date" required autoFocus className="form-control"
+                        value={currentItinerary.return_date}
+                        onChange={changeItineraryState}
+                    />
+                </div>
+                <div className="field">
+                    <label htmlFor="content" className="label">Categories: </label>
+                    {
+                        categories.map(category => {
+                            // Compare current category `id` and see if an object exists with that id in currentItinerary.categories
+                            const foundCategory = currentItinerary.categories.find(itineraryCategory => category.id === itineraryCategory.id)
+
+                            return <div key={`category--${category.id}`}>
+                                <input type="checkbox" name={category.category}
+                                    defaultChecked={foundCategory}
+                                    onClick={() => categoryArr(category.id) } />
+                                <label htmlFor={category.category}>{category?.category}</label><br/>
+                            </div>
+                        })
+
+                    }</div>
+            </fieldset>
+            <div className="row my-5 mx-5">
+                <button type="submit"
+                    onClick={evt => {
+                        // Prevent form from being submitted
+                        evt.preventDefault()
+
+                        const itinerary = {
+                            id: currentItinerary.id,
+                            name: currentItinerary.name,
+                            itinerary_description: currentItinerary.itinerary_description,
+                            date: currentItinerary.date,
+                            start_time: currentItinerary.start_time,
+                            end_time: currentItinerary.end_time,
+                            city: currentItinerary.city,
+                            state_or_country: currentItinerary.state_or_country,
+                            trip: tripId,
+                            categories: Array.from(itineraryCategories)
+                        }
+
+                        // If there is a itineraryId route parameter, invoke updateItinerary, otherwise createItinerary
+                        itineraryId ? updateItinerary(itineraryId, itinerary).then(() => navigate(`/trips/${tripId}`))
+                        : createItinerary(itinerary).then(() => navigate(`/trips/${tripId}`))
+                    }}
+                    className="btn btn-primary col-3">
+                        {
+                            itineraryId ? "Update" : "Create"
+                        }
+                </button>
+                <Link to={`/trips/${tripId}`} className="btn btn-primary col-3">Close</Link>
+            </div>
+        </form>
+    )
+}

--- a/src/components/managers/ItineraryManager.js
+++ b/src/components/managers/ItineraryManager.js
@@ -34,6 +34,6 @@ export const deleteItinerary = (itinerary_id) => {
     })
 }
 
-export const getReasons = () => {
-    return fetchIt(`${API}/itineraries/reasons`)
+export const getCategories = () => {
+    return fetchIt(`${API}/itineraries/categories`)
 }

--- a/src/components/managers/ItineraryManager.js
+++ b/src/components/managers/ItineraryManager.js
@@ -1,0 +1,39 @@
+import { fetchIt } from "../utilities/fetchIt.js"
+
+const API = "http://localhost:8000"
+
+export const getItineraries = () => {
+    return fetchIt(`${API}/itineraries`)
+}
+
+export const getItinerary = (itinerary_id) => {
+    return fetchIt(`${API}/itineraries/${itinerary_id}`)
+}
+
+export const getItinerariesByTrip = (trip_id) => {
+    return fetchIt(`${API}/itineraries?trip_id=${trip_id}`)
+}
+
+export const createItinerary = (itinerary) => {
+    return fetchIt(`${API}/itineraries`, {
+        method: 'POST',
+        body: JSON.stringify(itinerary)
+    })
+}
+
+export const updateItinerary = (itineraryId, itinerary) => {
+    return fetchIt(`${API}/itineraries/${itineraryId}`, {
+        method: 'PUT',
+        body: JSON.stringify(itinerary)
+    })
+}
+
+export const deleteItinerary = (itinerary_id) => {
+    return fetchIt(`${API}/itineraries/${itinerary_id}`, {
+        method: 'DELETE'
+    })
+}
+
+export const getReasons = () => {
+    return fetchIt(`${API}/itineraries/reasons`)
+}

--- a/src/components/trips/TripDetails.js
+++ b/src/components/trips/TripDetails.js
@@ -5,16 +5,17 @@ import { useParams } from "react-router-dom"
 import { Link } from "react-router-dom"
 import { getTrip } from "../managers/TripManager"
 import { Itineraries } from "../itineraries/Itineraries"
+import { ItineraryForm } from "../itineraries/ItineraryForm"
 
 export const TripDetails = () => {
     const { tripId } = useParams()
     const [trip, setTrip] = useState({
-        "name": "",
-        "city": "",
-        "state_or_country": "",
-        "departure_date": "",
-        "return_date": "",
-        "reasons": []
+        name: "",
+        city: "",
+        state_or_country: "",
+        departure_date: "",
+        return_date: "",
+        reasons: []
     })
 
     useEffect(() => {
@@ -22,9 +23,18 @@ export const TripDetails = () => {
         getTrip(id).then(data => setTrip(data))
     }, [tripId])
 
+    const handleClick = () => {
+        
+        return <ItineraryForm tripId={tripId}/>
+    }
+
     return <>
     <div className="row my-5 mx-5">
         <Link to={`/trips/edit/${tripId}`} className="btn btn-primary col-3">Edit Trip</Link>
+    </div>
+    <h5 style={{textAlign: 'center'}}>Trip Itineraries</h5>
+    <div className="row my-1 mx-5">
+        <button className="btn btn-primary col-3" onClick={handleClick}>Add Itinerary</button>
     </div>
     <Itineraries tripId={tripId}/>
     </>

--- a/src/components/trips/TripDetails.js
+++ b/src/components/trips/TripDetails.js
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { useParams } from "react-router-dom"
 import { Link } from "react-router-dom"
 import { getTrip } from "../managers/TripManager"
+import { Itineraries } from "../itineraries/Itineraries"
 
 export const TripDetails = () => {
     const { tripId } = useParams()
@@ -25,6 +26,6 @@ export const TripDetails = () => {
     <div className="row my-5 mx-5">
         <Link to={`/trips/edit/${tripId}`} className="btn btn-primary col-3">Edit Trip</Link>
     </div>
-    
+    <Itineraries tripId={tripId}/>
     </>
 }

--- a/src/components/trips/TripDetails.js
+++ b/src/components/trips/TripDetails.js
@@ -23,10 +23,6 @@ export const TripDetails = () => {
         getTrip(id).then(data => setTrip(data))
     }, [tripId])
 
-    const handleClick = () => {
-        
-        return <ItineraryForm tripId={tripId}/>
-    }
 
     return <>
     <div className="row my-5 mx-5">
@@ -34,7 +30,7 @@ export const TripDetails = () => {
     </div>
     <h5 style={{textAlign: 'center'}}>Trip Itineraries</h5>
     <div className="row my-1 mx-5">
-        <button className="btn btn-primary col-3" onClick={handleClick}>Add Itinerary</button>
+        <Link className="btn btn-primary col-3" to={`/itineraries/${tripId}/new`}>Add Itinerary</Link>
     </div>
     <Itineraries tripId={tripId}/>
     </>

--- a/src/components/trips/TripForm.js
+++ b/src/components/trips/TripForm.js
@@ -18,7 +18,7 @@ export const TripForm = () => {
         return_date: "",
         reasons: []
     })
-
+    
     const reasonArr = (reasonId) => {
         let copy = new Set(tripReasons)
         copy.has(reasonId) ? copy.delete(reasonId) : copy.add(reasonId)
@@ -110,7 +110,6 @@ export const TripForm = () => {
 
                     }</div>
             </fieldset>
-            <Link to={`/itineraries/new`} className="btn btn-primary col-3">Add Itinerary</Link>
             <div className="row my-5 mx-5">
                 <button type="submit"
                     onClick={evt => {
@@ -136,7 +135,7 @@ export const TripForm = () => {
                             tripId ? "Update" : "Create"
                         }
                 </button>
-                <Link to={`trips`} className="btn btn-primary col-3">Cancel</Link>
+                <Link to={`/trips`} className="btn btn-primary col-3">Close</Link>
             </div>
         </form>
     )

--- a/src/components/trips/TripForm.js
+++ b/src/components/trips/TripForm.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { useNavigate, useParams } from 'react-router-dom'
+import { Link } from "react-router-dom"
 import { getTrip, createTrip, updateTrip, getReasons } from "../managers/TripManager"
 
 export const TripForm = () => {
@@ -109,6 +110,7 @@ export const TripForm = () => {
 
                     }</div>
             </fieldset>
+            <Link to={`/itineraries/new`} className="btn btn-primary col-3">Add Itinerary</Link>
             <div className="row my-5 mx-5">
                 <button type="submit"
                     onClick={evt => {
@@ -134,7 +136,7 @@ export const TripForm = () => {
                             tripId ? "Update" : "Create"
                         }
                 </button>
-                <a href="http://localhost:3000/trips" class="btn btn-primary col-3">Cancel</a>
+                <Link to={`trips`} className="btn btn-primary col-3">Cancel</Link>
             </div>
         </form>
     )

--- a/src/components/views/ApplicationViews.js
+++ b/src/components/views/ApplicationViews.js
@@ -2,15 +2,19 @@ import { Route, Outlet, Routes } from "react-router-dom"
 import { Trips } from "../trips/Trips"
 import { TripDetails } from "../trips/TripDetails"
 import { TripForm } from "../trips/TripForm"
+import { Itineraries } from "../itineraries/Itineraries"
+import { ItineraryDetails } from "../itineraries/ItineraryDetails"
 
 export const ApplicationViews = () => {
 	return (
     <Routes>
       <Route path="/home" element={<Outlet />} />
       <Route path="/trips" element={<Trips />} />
+      <Route path="/trips/:tripId" element={<TripDetails />} />
       <Route path="/trips/new" element={<TripForm />} />
       <Route path="/trips/edit/:tripId" element={<TripForm />} />
-      <Route path="/trips/:tripId" element={<TripDetails />} />
+      <Route path="/itineraries" element={<Itineraries />} />
+      <Route path="/itineraries/:itineraryId" element={<ItineraryDetails />} />
     </Routes>
   );
 }

--- a/src/components/views/ApplicationViews.js
+++ b/src/components/views/ApplicationViews.js
@@ -4,6 +4,7 @@ import { TripDetails } from "../trips/TripDetails"
 import { TripForm } from "../trips/TripForm"
 import { Itineraries } from "../itineraries/Itineraries"
 import { ItineraryDetails } from "../itineraries/ItineraryDetails"
+import { ItineraryForm } from "../itineraries/ItineraryForm"
 
 export const ApplicationViews = () => {
 	return (
@@ -15,6 +16,8 @@ export const ApplicationViews = () => {
       <Route path="/trips/edit/:tripId" element={<TripForm />} />
       <Route path="/itineraries" element={<Itineraries />} />
       <Route path="/itineraries/:itineraryId" element={<ItineraryDetails />} />
+      <Route path="/itineraries/new" element={<ItineraryForm />} />
+      <Route path="/itineraries/edit/:itineraryId" element={<ItineraryForm />} />
     </Routes>
   );
 }

--- a/src/components/views/ApplicationViews.js
+++ b/src/components/views/ApplicationViews.js
@@ -16,8 +16,8 @@ export const ApplicationViews = () => {
       <Route path="/trips/edit/:tripId" element={<TripForm />} />
       <Route path="/itineraries" element={<Itineraries />} />
       <Route path="/itineraries/:itineraryId" element={<ItineraryDetails />} />
-      <Route path="/itineraries/new" element={<ItineraryForm />} />
-      <Route path="/itineraries/edit/:itineraryId" element={<ItineraryForm />} />
+      <Route path="/itineraries/:tripId/new" element={<ItineraryForm />} />
+      {/* <Route path="/itineraries/edit/:itineraryId" element={<ItineraryForm />} /> */}
     </Routes>
   );
 }


### PR DESCRIPTION
## Description

When the user is on the trip details page and clicks the add itinerary button, the client will present a new itinerary form.  Then, the client will route the user back to the trip details page and display a list of the trip itineraries. 

## Changes
- Created an itinerary manager component 
- Created an itinerary list component 
- Created an itinerary form 
- Added an add itinerary button to /trips/{tripId}

## Steps to test

```
git fetch origin vs-itinerary-manager
git checkout vs-itinerary-manager
```
- Login and navigate to a trip's details page 
```username=dgarcia@travel.com password: globetrotter```
- Click on the add itinerary button and go through the form to create a new itinerary.  Verify the client routes back to the trip's details page after the form is submitted and that you're new itinerary appears in the itinerary list

## Related Issues
- Closes #4 
- Closes #5 
- Closes #7 