### PR TITLE
Client can now delete a trip

### DIFF
--- a/src/components/trips/TripDetails.js
+++ b/src/components/trips/TripDetails.js
@@ -2,13 +2,14 @@
 
 import { useState, useEffect } from "react"
 import { useParams } from "react-router-dom"
+import { useNavigate } from 'react-router-dom'
 import { Link } from "react-router-dom"
-import { getTrip } from "../managers/TripManager"
+import { getTrip, deleteTrip } from "../managers/TripManager"
 import { Itineraries } from "../itineraries/Itineraries"
-import { ItineraryForm } from "../itineraries/ItineraryForm"
 
 export const TripDetails = () => {
     const { tripId } = useParams()
+    const navigate = useNavigate()
     const [trip, setTrip] = useState({
         name: "",
         city: "",
@@ -27,6 +28,16 @@ export const TripDetails = () => {
     return <>
     <div className="row my-5 mx-5">
         <Link to={`/trips/edit/${tripId}`} className="btn btn-primary col-3">Edit Trip</Link>
+        <button className="btn btn-primary col-3" onClick={() => {
+                if (
+                    window.confirm(
+                      `Are you sure you want to delete this trip?`
+                    )
+                )
+                deleteTrip(tripId)
+                    .then(() => navigate(`/trips`))
+            }
+            }>Delete</button>
     </div>
     <h5 style={{textAlign: 'center'}}>Trip Itineraries</h5>
     <div className="row my-1 mx-5">


### PR DESCRIPTION
## Description

When the user is on a trip's details page and clicks the **delete**, the client will delete the trip and route the user back to their trips page.

## Changes
- Added a delete button to the trip details component the deletes the selected trip

## Steps to test

```
git fetch origin vs-delete-trip
git checkout vs-delete-trip
```
- Login and navigate to a trip's details page 
```username=dgarcia@travel.com password: globetrotter```
- Click on the **delete** button and confirm the deletion
- Verify that the client routes you back to the trips page and that the trip has been removed from the list

## Related Issues
- Closes #8