### PR TITLE
Updated onclick listeners for trip notes and packing list to use cust…

### DIFF
--- a/src/components/trips/PackingList.js
+++ b/src/components/trips/PackingList.js
@@ -1,12 +1,10 @@
 // Generate a list of trip notes added by the user
 
-import { useNavigate } from 'react-router-dom'
 import { useState, useEffect } from "react"
 import { getPackingListByTrip, addItem, deleteItem, getItem, updateItem } from "../managers/PackingListManager"
 
 export const PackingList = ({ tripId }) => {
 
-    const navigate = useNavigate()
     const [packingList, setPackingList] = useState([])
     const [newItem, setNewItem] = useState("")
 
@@ -20,26 +18,37 @@ export const PackingList = ({ tripId }) => {
         []
     ) 
 
-    useEffect(
-        () => {
-            getPackingListByTrip(tripId)
-            .then( packingListArray => {
-                setPackingList(packingListArray)
-            })
-        },
-        [packingList]
-    ) 
-
-    const changeNewItemState = (event) => {
-        const copy = { ...newItem }
-        copy[event.target.name] = event.target.value
-        setNewItem(copy)
-    }
-
     async function updateCurrentItem (evt) {
         let item = await getItem(parseInt(evt.target.id))
         item["packed"] = !(item.packed)
         await updateItem(item.id, item)
+    }
+
+    async function createNewItem () {
+        
+        const itemToPost = {
+            trip_id: tripId,
+            item: newItem,
+            packed: false
+        }
+
+        setNewItem("")
+
+        await addItem(itemToPost)
+
+        await getPackingListByTrip(tripId)
+                .then( packingListArray => {
+                    setPackingList(packingListArray)
+                })
+    }
+
+    async function deleteCurrentItem(event) {
+        await deleteItem(parseInt(event.target.id))
+
+        await getPackingListByTrip(tripId)
+            .then( packingListArray => {
+                setPackingList(packingListArray)
+            })
     }
 
     return <>
@@ -48,18 +57,10 @@ export const PackingList = ({ tripId }) => {
             <h5 style={{textAlign: 'center'}}>Packing List</h5>
         </div>
         <div className="row col-11 mx-auto my-2 form-group">
-            <textarea className="form-control" rows="4" name="item" value={newItem.item} onChange={changeNewItemState}/>
+            <textarea className="form-control" rows="4" name="item" value={newItem} onChange={(evt) => setNewItem(evt.target.value)}/>
         </div>
         <div className='row col-6 mx-auto my-2'>
-            <button type="button" className="btn btn-primary my-2" onClick={() => {
-                
-                const itemToPost = {
-                    trip_id: tripId,
-                    item: newItem.item,
-                    packed: false
-                }
-
-                addItem(itemToPost)}}
+            <button type="button" className="btn btn-primary my-2" onClick={createNewItem}
             >Add Item</button>
         </div>
             <div className="card my-5 mx-5">
@@ -74,8 +75,8 @@ export const PackingList = ({ tripId }) => {
                                         onClick={(evt) =>  updateCurrentItem(evt)} />
                                     <label htmlFor={item.item}>{item?.item}</label><br/>
 
-                                <button type="button" style={{float: "right"}} className="btn btn-primary btn-sm" onClick={() => 
-                                    {deleteItem(item.id)}}
+                                <button type="button" style={{float: "right"}} id={item.id} className="btn btn-primary btn-sm" onClick={(event) => 
+                                    {deleteCurrentItem(event)}}
                                 >Delete</button>
                                 </li>
                             </div>

--- a/src/components/trips/TripNotes.js
+++ b/src/components/trips/TripNotes.js
@@ -17,19 +17,8 @@ export const TripNotes = ({ tripId }) => {
         },
         []
     ) 
-    
-    useEffect(
-        () => {
-            getTripNotesByTrip(tripId)
-            .then( notesArray => {
-                setNotes(notesArray)
-            })
-        },
-        [notes]
-    ) 
 
-    const handleSubmit = (evt) => {
-        evt.preventDefault()
+    async function createNewNote () {
 
         const noteToPost = {
             trip_id: tripId,
@@ -38,8 +27,22 @@ export const TripNotes = ({ tripId }) => {
 
         setNewNote("")
         
-        createTripNote(noteToPost)
+        await createTripNote(noteToPost)
 
+        await getTripNotesByTrip(tripId)
+            .then( notesArray => {
+                setNotes(notesArray)
+            })
+
+    }
+
+    async function deleteCurrentNote(event) {
+        await deleteTripNote(parseInt(event.target.id))
+
+        await  getTripNotesByTrip(tripId)
+            .then( notesArray => {
+                setNotes(notesArray)
+            })
     }
 
     return <>
@@ -48,10 +51,10 @@ export const TripNotes = ({ tripId }) => {
             <h5 style={{textAlign: 'center'}}>Trip Notes</h5>
         </div>
         <div className="row col-11 mx-auto my-2 form-group">
-            <textarea className="form-control" rows="4" name="trip_note" value={newNote} onChange={ (event) => setNewNote(event.target.value)}/>
+            <textarea className="form-control" rows="4" name="trip_note" value={newNote} onChange={(event) => setNewNote(event.target.value)}/>
         </div>
         <div className='row col-6 mx-auto my-2'>
-            <button type="button" className="btn btn-primary my-2" onClick={(evt) => {handleSubmit(evt)}}
+            <button type="button" className="btn btn-primary my-2" onClick={createNewNote}
             >Add Note</button>
         </div>
             <div className="card my-5 mx-5">
@@ -61,8 +64,8 @@ export const TripNotes = ({ tripId }) => {
                             <div className='row' key={`tripNote--${note.id}`}>
                                 <li className="list-group-item">
                                     {note.trip_note}
-                                <button type="button" style={{float: "right"}} className="btn btn-primary btn-sm" onClick={() => 
-                                    {deleteTripNote(note.id)}}
+                                <button type="button" style={{float: "right"}} id={note.id} className="btn btn-primary btn-sm" onClick={(event) => 
+                                    {deleteCurrentNote(event)}}
                                 >Delete</button>
                                 </li>
                             </div>


### PR DESCRIPTION
## Description 

The useEffects watching [packingList] were causing an infinite loop upon initial page render.  Instead of using useEffects to re-render the page after a trip note or packing item has been added or deleted, the onclick function has been updated to a custom function.  These custom functions make the server request and then grab the packing list or notes list again.

## Description 
The client needs to be able to display whether or not an item has been packed.  The client uses checkboxes for this functionality.  The server and database need to be updated to support the packing list checkboxes and a boolean "packed" field has been added to correspond with the client checkboxes.  The default state of "packed" is false, and when the user clicks the checkbox, the client will send a request to update the "packed" field to true. 

## Requests / Responses

**Request**

POST `/packinglist` Creates a new item

```json
{
    "trip_id": 1,
    "item": "Flip-flops",
    "packed": false
}
```

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 20,
    "trip": {
        "id": 1,
        "name": "Spring Break Trip",
        "city": "Key West",
        "state_or_country": "Florida",
        "departure_date": "2018-03-16",
        "return_date": "2018-03-18",
        "user": 1,
        "reasons": [
            1
        ]
    },
    "item": "Flip-flops",
    "packed": false
}
```

## Testing

```
git fetch origin vs-list-updates
git checkout vs-list-updates
```
- Pull down changes from passport-server repository, pull request # 30
- Delete database and run migrations to update packing database models
- Load fixtures 
- Add an item to packing list 
- Select the checkbox and verify it shows as checked 
- Refresh the page and verify it still shows as checked
- Delete an item and verify it has been removed from the packing list 