### PR TITLE
Client can now display upcoming trip count

### DIFF
--- a/src/components/managers/TripManager.js
+++ b/src/components/managers/TripManager.js
@@ -37,3 +37,7 @@ export const deleteTrip = (trip_id) => {
 export const getReasons = () => {
     return fetchIt(`${API}/trips/reasons`)
 }
+
+export const getUpcomingTripCount = () => {
+    return fetchIt(`${API}/trips/upcoming`)
+}

--- a/src/components/trips/Trips.js
+++ b/src/components/trips/Trips.js
@@ -2,7 +2,7 @@
 //Trip cards are hyperlinked to trip's details page
 
 import { useEffect, useState } from "react"
-import { getTripsByUser } from "../managers/TripManager"
+import { getTripsByUser, getUpcomingTripCount } from "../managers/TripManager"
 import { Link } from "react-router-dom"
 import { Trip } from "./Trip"
 
@@ -11,6 +11,7 @@ export const Trips = () => {
 const localUser = localStorage.getItem("passport_token")
 const userObject = JSON.parse(localUser)
 const [trips, setTrips] = useState([])
+const [upcomingTripCount, setUpcomingTripCount] = useState([])
 
 useEffect(
     () => {
@@ -18,12 +19,20 @@ useEffect(
         .then( userTripsArray => {
             setTrips(userTripsArray)
         })
+
+        getUpcomingTripCount()
+        .then( data => {
+            setUpcomingTripCount(data)
+        })
     },
     []
 ) 
 
 return <>
-    <div className="row my-5 mx-5">
+    <div className="row my-5 mx-5" style={{textAlign: 'center'}}>
+        <h1>You have {upcomingTripCount} upcoming trips!</h1>
+    </div>
+    <div className="row my-4 mx-5">
         <Link to={`/trips/new`} className="btn btn-primary col-3">Add Trip</Link>
     </div>
     <div className="row">


### PR DESCRIPTION
## Description

On the trips page, the client will now display the number of upcoming trips that the user has planned.

## Changes 
- Added a state variable and get function to get request the upcoming trip count from server 
- Added a header tag to display the number of upcoming trips 

## Steps to test 
```
git fetch origin vs-trip-count
get checkout vs-trip-count
```
- Pull down branch from passport-server repository pull request # 31
- Navigate to the trips page
- Verify that the trip count is displaying in a header 
- Add a trip with a future departure date 
- Verify that the trip count updated to account for the additional trip 