### PR TITLE
Client can now create a new stamp

### DIFF
--- a/src/components/managers/StampManager.js
+++ b/src/components/managers/StampManager.js
@@ -1,0 +1,9 @@
+// Handles fetch requests for all Stamp interactions
+
+import { fetchIt } from "../utilities/fetchIt.js"
+
+const API = "http://localhost:8000"
+
+export const getTypes = () => {
+    return fetchIt(`${API}/stamps/types`)
+}

--- a/src/components/managers/StampManager.js
+++ b/src/components/managers/StampManager.js
@@ -7,3 +7,10 @@ const API = "http://localhost:8000"
 export const getTypes = () => {
     return fetchIt(`${API}/stamps/types`)
 }
+
+export const createStampPhoto = (stamp) => {
+    return fetchIt(`${API}/stamps/photos`, {
+        method: 'POST',
+        body: JSON.stringify(stamp)
+    })
+}

--- a/src/components/stamps/StampForm.js
+++ b/src/components/stamps/StampForm.js
@@ -1,0 +1,128 @@
+//Presents the form for adding a new stamp
+
+import { useState, useEffect } from "react"
+import { getPastTrips } from "../managers/TripManager"
+import { getItinerariesByTrip } from "../managers/ItineraryManager"
+import { getTypes } from "../managers/StampManager"
+import { StampPhoto } from "./StampPhoto"
+import { StampJournal } from "./StampJournal"
+import { StampProduct } from "./StampProduct"
+
+export const StampForm = () => {
+
+    const [trips, setTrips] = useState([])
+    const [itineraries, setItineraries] = useState([])
+    const [selectedTrip, setSelectedTrip] = useState(0)
+    const [selectedItinerary, setSelectedItinerary] = useState(null)
+    const [types, setTypes] = useState([])
+    const [selectedType, setSelectedType] = useState({})
+
+    useEffect(
+        () => {
+            getPastTrips()
+            .then( tripsArray => {
+                setTrips(tripsArray)
+            })
+
+            getTypes()
+            .then( typesArray => {
+                setTypes(typesArray)
+            })
+        },
+        []
+    )
+    
+    const handleTripChange = (event) => {
+        
+        const tripId = parseInt(event.target.value)
+        setSelectedTrip(tripId)
+
+        //Get all itineraries associated with the trip
+        getItinerariesByTrip(tripId)
+        .then( itinerariesArray => {
+            setItineraries(itinerariesArray)
+        })
+    }
+
+    useEffect(
+        () => {
+            console.log(`You're creating a new stamp`)
+        },
+        [selectedType]
+    )    
+
+    return <>
+    
+    <div className="container">
+        <form className="stampForm">
+        <h2 className="stampForm__title">New Stamp</h2>
+        <fieldset>
+            <div className="form-group">
+                <label htmlFor="trip">Trip</label>
+                <select
+                    className="form-control"
+                    onChange={ (event) => {handleTripChange(event)}}
+                    >
+                    <option value={0}>Select a trip...</option>
+                    {
+                        trips.map(trip => {
+                            return <option value={trip.id} key={`trip--${trip.id}`}>{trip.name}</option>
+                        })
+                    }
+                </select>
+            </div>
+        </fieldset>
+        {
+            itineraries.length > 0 ? (
+                <fieldset>
+                    <div className="form-group">
+                        <label htmlFor="itinerary">Itinerary (Optional)</label>
+                        <select
+                            className="form-control"
+                            onChange={ (event) => {
+                                setSelectedItinerary(parseInt(event.target.value))
+                            }}
+                            >
+                            <option value={null}>Select an itinerary...</option>
+                            {
+                                itineraries.map(itinerary => {
+                                    return <option value={itinerary.id} key={`itinerary--${itinerary.id}`}>{itinerary.name}</option>
+                                })
+                            }
+                        </select>
+                    </div>
+                </fieldset>
+            ) : ""
+        }
+        <fieldset>
+            <div className="form-group">
+                <label htmlFor="type">Stamp Type</label>
+                <select
+                    className="form-control"
+                    onChange={ (event) => {
+                        setSelectedType(parseInt(event.target.value))
+                    }}
+                    >
+                    <option value={0}>Select a stamp type...</option>
+                    {
+                        types.map(type => {
+                            return <option value={type.id} key={`type--${type.id}`}>{type.type}</option>
+                        })
+                    }
+                </select>
+            </div>
+        </fieldset>
+        {
+            selectedType==1 ? <StampPhoto selectedTrip={selectedTrip} selectedItinerary={selectedItinerary}/> : ""
+        }
+        {
+            selectedType==2 ? <StampJournal selectedTrip={selectedTrip} selectedItinerary={selectedItinerary}/> : ""
+        }
+        {
+            selectedType==3 ? <StampProduct selectedTrip={selectedTrip} selectedItinerary={selectedItinerary}/> : ""
+        }
+        </form>
+    </div>
+    
+    </>
+}

--- a/src/components/stamps/StampForm.js
+++ b/src/components/stamps/StampForm.js
@@ -113,13 +113,13 @@ export const StampForm = () => {
             </div>
         </fieldset>
         {
-            selectedType==1 ? <StampPhoto selectedTrip={selectedTrip} selectedItinerary={selectedItinerary}/> : ""
+            selectedType==1 ? <StampPhoto selectedTrip={selectedTrip} selectedItinerary={selectedItinerary} selectedType={selectedType}/> : ""
         }
         {
-            selectedType==2 ? <StampJournal selectedTrip={selectedTrip} selectedItinerary={selectedItinerary}/> : ""
+            selectedType==2 ? <StampJournal selectedTrip={selectedTrip} selectedItinerary={selectedItinerary} selectedType={selectedType}/> : ""
         }
         {
-            selectedType==3 ? <StampProduct selectedTrip={selectedTrip} selectedItinerary={selectedItinerary}/> : ""
+            selectedType==3 ? <StampProduct selectedTrip={selectedTrip} selectedItinerary={selectedItinerary} selectedType={selectedType}/> : ""
         }
         </form>
     </div>

--- a/src/components/stamps/StampJournal.js
+++ b/src/components/stamps/StampJournal.js
@@ -1,0 +1,6 @@
+// Presents the journal form for adding a new stamp with type = journal
+
+export const StampJournal = () => {
+
+    return <><h5>This is a stamp journal</h5></>
+}

--- a/src/components/stamps/StampPhoto.js
+++ b/src/components/stamps/StampPhoto.js
@@ -1,0 +1,6 @@
+// Presents the photo form for adding a new stamp with type = photo
+
+export const StampPhoto = () => {
+
+    return <><h5>This is a stamp photo</h5></>
+}

--- a/src/components/stamps/StampPhoto.js
+++ b/src/components/stamps/StampPhoto.js
@@ -1,6 +1,70 @@
 // Presents the photo form for adding a new stamp with type = photo
 
-export const StampPhoto = () => {
+import { useState } from "react"
+import { useNavigate } from 'react-router-dom'
+import { createStampPhoto } from "../managers/StampManager";
 
-    return <><h5>This is a stamp photo</h5></>
+export const StampPhoto = ({ selectedTrip, selectedItinerary, selectedType}) => {
+
+    const navigate = useNavigate()
+    const [stamp, setStamp] = useState({
+        image: null,
+        description: "",
+        trip: selectedTrip,
+        itinerary: selectedItinerary,
+        type: selectedType, 
+        public: false
+    })
+
+    const getBase64 = (file, callback) => {
+        const reader = new FileReader();
+        reader.addEventListener('load', () => callback(reader.result));
+        reader.readAsDataURL(file);
+    }
+
+    const createStampImageString = (event) => {
+        getBase64(event.target.files[0], (base64ImageString) => {
+            
+            const copy = { ...stamp }
+            copy["image"] = base64ImageString
+            setStamp(copy)
+        });
+    }
+
+    async function handleSubmit (event) {
+        event.preventDefault()
+
+        await createStampPhoto(stamp)
+            .then(() => navigate("/stamps"))
+    }
+
+    return <>
+        <fieldset>
+            <label htmlFor="stamp_image">Photo</label>
+            <input type="file" name="stamp_image" accept="image/*" onChange={createStampImageString} />
+        </fieldset>
+        <fieldset>
+        <fieldset>
+            <label htmlFor="description">Caption</label>
+            <input type="text" name="description" required autoFocus className="form-control"
+                value={stamp.description}
+                onChange={(event) => {
+                    const copy = { ...stamp }
+                    copy[event.target.name] = event.target.value
+                    setStamp(copy)
+                }}
+            />
+        </fieldset>
+            <label htmlFor="public">Public</label>
+            <input type="checkbox" name="public" defaultChecked={stamp.public} onClick={(event) => {
+                 const copy = { ...stamp }
+                 copy[event.target.name] = event.target.checked
+                 setStamp(copy)
+            }} />
+        </fieldset>
+        <div className="row my-5 mx-5">
+            <button className="btn btn-primary col-3" type="submit" onClick={(event) => {handleSubmit(event)}}>
+            Save</button>
+        </div>
+    </>
 }

--- a/src/components/stamps/StampProduct.js
+++ b/src/components/stamps/StampProduct.js
@@ -1,0 +1,6 @@
+// Presents the product form for adding a new stamp with type = product
+
+export const StampProduct = () => {
+
+    return <><h5>This is a stamp product</h5></>
+}

--- a/src/components/stamps/Stamps.js
+++ b/src/components/stamps/Stamps.js
@@ -1,10 +1,17 @@
 //Primary page for stamps' components
 
 import { TripsMap } from "./TripsMap"
+import { Link } from 'react-router-dom'
 
 export const Stamps = () => {
     
     return <>
         <TripsMap />
+
+        <div className="container">
+            <div className="row my-4 mx-5">
+                <Link to={`/stamps/new`} className="btn btn-primary col-3">Add Stamp</Link>
+            </div>
+        </div>
     </>
 }

--- a/src/components/views/ApplicationViews.js
+++ b/src/components/views/ApplicationViews.js
@@ -7,6 +7,7 @@ import { ItineraryDetails } from "../itineraries/ItineraryDetails"
 import { ItineraryForm } from "../itineraries/ItineraryForm"
 import { EditItinerary } from "../itineraries/EditItinerary"
 import { Stamps } from "../stamps/Stamps"
+import { StampForm } from "../stamps/StampForm"
 
 export const ApplicationViews = () => {
 	return (
@@ -21,6 +22,7 @@ export const ApplicationViews = () => {
       <Route path="/itineraries/:tripId/new" element={<ItineraryForm />} />
       <Route path="/itineraries/edit/:itineraryId" element={<EditItinerary />} />
       <Route path="/stamps" element={<Stamps />} />
+      <Route path="/stamps/new" element={<StampForm />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Description

The client can now add a new stamp photo to their stamps page.  They can also view the other stamp types (product and journal), but these stamp types still need additional work to be features. 

## Changes 
- Created a stamp manager to handle all fetch requests
- Created a stamps component as the parent component to handle all things stamps 
- Created a stamp form that dynamically updates based on the type of stamp selected 
- Created a stamp photo component to post a new stamp photo

## Testing

```
git fetch origin vs-stamp-view
git checkout vs-stamp-view
```
- Pull down changes from passport-server repo, pull request # 33
- Create and run database migrations 
- Navigate to stamps and click on the add stamp button 
- Select a trip from the dropdown and select photo from the type dropdown
- Upload a photo and add a caption 
- Click the save button 
- Verify the new stamp photo posted to the database
- Note: The photo won't show on the app at this time.  The stamps list component still needs to be created. 

## Related issues 
- Closes #11 
- Closes #16 